### PR TITLE
layout: Disable DnD on app grid clones

### DIFF
--- a/ui/layout.js
+++ b/ui/layout.js
@@ -70,6 +70,11 @@ class OverviewClone extends St.BoxLayout {
         this._overviewHiddenId = Main.overview._nextConnectionId;
 
         const appDisplayClone = new AppDisplay.AppDisplay();
+
+        // Disable DnD on clones
+        appDisplayClone._disconnectDnD();
+        appDisplayClone._connectDnD = function() {};
+
         AppDisplayOverrides.changeAppGridOrientation(
             Clutter.Orientation.HORIZONTAL,
             appDisplayClone);


### PR DESCRIPTION
Some of the DnD changes don't actually depend on the
actor being pickable, and can pretty easily break the
clones.

Disable DnD on these clones.

https://phabricator.endlessm.com/T30623