### PR TITLE
viewSelector: Toggle checkbutton after overview is hidden

### DIFF
--- a/ui/viewSelector.js
+++ b/ui/viewSelector.js
@@ -60,10 +60,13 @@ function enable() {
 
         this._workspacesDisplay.animateFromOverview(this._activePage != this._workspacesPage);
 
-        this._showAppsButton.checked = true;
-
         if (!this._workspacesDisplay.activeWorkspaceHasMaximizedWindows())
             Main.overview.fadeInDesktop();
+
+        const id = Main.overview.connect('hidden', () => {
+            this._showAppsButton.checked = true;
+            Main.overview.disconnect(id);
+        })
     });
 
 


### PR DESCRIPTION
Otherwise, we make both the fade-to-app-grid animation and
the back-to-original-position animations run in parallel.

https://phabricator.endlessm.com/T30738