### PR TITLE
extension: Enable workspace monitor after configuring overrides

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -40,7 +40,6 @@ class Extension {
 
         await Settings.migrate();
 
-        this._workspaceMonitor.enable();
         AppDisplay.enable();
         Dash.enable();
         Keybindings.enable();
@@ -48,6 +47,7 @@ class Extension {
         ViewSelector.enable();
         Overview.enable();
         Search.enable();
+        this._workspaceMonitor.enable();
 
         this._enabled = true;
     }

--- a/ui/layout.js
+++ b/ui/layout.js
@@ -231,6 +231,8 @@ function enable() {
     if (startupPreparedId === 0) {
         startupPreparedId =
             Main.layoutManager.connect('startup-prepared', () => {
+                if (Main.overview.visible)
+                    Main.overview.hide();
                 Main.overview.show();
             });
     }


### PR DESCRIPTION
This makes sure the overview is updated after the overrides are in place and avoids updating it while setting up the overrides.

https://phabricator.endlessm.com/T30597