### PR TITLE
layout: Don't allow clones to save pages

### DIFF
--- a/ui/layout.js
+++ b/ui/layout.js
@@ -87,6 +87,7 @@ class OverviewClone extends St.BoxLayout {
         // Disable DnD on clones
         appDisplayClone._disconnectDnD();
         appDisplayClone._connectDnD = function() {};
+        appDisplayClone._savePages = function() {};
 
         AppDisplayOverrides.changeAppGridOrientation(
             Clutter.Orientation.HORIZONTAL,


### PR DESCRIPTION
We absolutely never want clones to actually save pages. With
the latest fixes from GNOME Shell, it is possible that the
clones end up saving pages, due to FolderIcon sending the
'apps-changed' signal.

Override the '_savePages' function from clones with an empty
stub.

https://phabricator.endlessm.com/T30808