### PR TITLE
layout: Make grid dirty when clone is mapped

### DIFF
--- a/ui/layout.js
+++ b/ui/layout.js
@@ -83,6 +83,7 @@ class OverviewClone extends St.BoxLayout {
 
         const appDisplayClone = new AppDisplay.AppDisplay();
         appDisplayClone.offscreen_redirect = Clutter.OffscreenRedirect.ALWAYS;
+        this._appDisplayClone = appDisplayClone;
 
         // Disable DnD on clones
         appDisplayClone._disconnectDnD();
@@ -128,6 +129,11 @@ class OverviewClone extends St.BoxLayout {
 
     setSearchHint(hint) {
         this._entry.hint_text = hint;
+    }
+
+    vfunc_map() {
+        super.vfunc_map();
+        this._appDisplayClone._grid.queue_redraw();
     }
 
     _onDestroy() {


### PR DESCRIPTION
This is, once again, another case of FBO contents not
being invalidated properly. In this case, what happens
is that the icon grid doesn't relayout when unmapped,
which skips marking it as dirty, which doesn't trigger
an FBO invalidation and redraw on both the offscreen
cache, and (most importantly) the desaturation effect.

This can be verified by disabling the desaturation
effect and noticing that invalidation happens on one
of the offscreen caches, and thus triggering a redraw
of the grid.

This is ultimately a problem in the paint machinery of
Clutter, but we can easily work around it by forcing the
actor to be marked as dirty after all parents are mapped.

https://phabricator.endlessm.com/T30964