### PR TITLE
layout: Also bind 'upper' on adjustments

### DIFF
--- a/ui/layout.js
+++ b/ui/layout.js
@@ -98,12 +98,14 @@ class OverviewClone extends St.BoxLayout {
 
         // Bind adjustments
         const { appDisplay } = Main.overview.viewSelector;
-        appDisplay._scrollView.hscroll.adjustment.bind_property('value',
-            appDisplayClone._scrollView.hscroll.adjustment, 'value',
-            GObject.BindingFlags.SYNC_CREATE);
-        appDisplay._scrollView.vscroll.adjustment.bind_property('value',
-            appDisplayClone._scrollView.vscroll.adjustment, 'value',
-            GObject.BindingFlags.SYNC_CREATE);
+        ['upper', 'value'].forEach(property => {
+            appDisplay._scrollView.hscroll.adjustment.bind_property(property,
+                appDisplayClone._scrollView.hscroll.adjustment, property,
+                GObject.BindingFlags.SYNC_CREATE);
+            appDisplay._scrollView.vscroll.adjustment.bind_property(property,
+                appDisplayClone._scrollView.vscroll.adjustment, property,
+                GObject.BindingFlags.SYNC_CREATE);
+        });
 
         // Added by this extension's ui/appDisplay.js file
         this._desaturateEffect = new Clutter.DesaturateEffect({


### PR DESCRIPTION
The 'upper' property of the clones' adjustments are only
updated after the first time it's mapped. However, at this
point, the real app grid itself may be on another page. The
clones can't reflect that because their adjustments' 'upper'
property is not yet updated with the number of pages.

Bind the 'upper' property of the real app grid's adjustments
with the clones'. This is fine because the number of pages
is decided based on the number of icons, not in the available
space.

https://phabricator.endlessm.com/T30964