### PR TITLE
style: Add margins around horizontal app display

### DIFF
--- a/stylesheet.scss
+++ b/stylesheet.scss
@@ -4,6 +4,10 @@
   padding-top: 48px;
 }
 
+.app-display {
+  margin: 0 30px;
+}
+
 .icon-grid {
   row-spacing: 18px;
   column-spacing: 18px;

--- a/ui/appDisplay.js
+++ b/ui/appDisplay.js
@@ -84,6 +84,7 @@ function changeAppGridOrientation(orientation, appDisplay = null) {
     appDisplay._pageIndicators = pageIndicators;
 
     if (vertical) {
+        appDisplay.remove_style_class_name('app-display');
         appDisplay._stack.add_child(scrollView);
         appDisplay.add_child(pageIndicators);
         scrollViewParent.destroy();
@@ -105,6 +106,7 @@ function changeAppGridOrientation(orientation, appDisplay = null) {
             });
 
         scrollView.remove_style_class_name('all-apps');
+        appDisplay.add_style_class_name('app-display');
     }
 
     appDisplay._scrollView.set_policy(


### PR DESCRIPTION
This makes it easier to drag icons between pages.