### PR TITLE
appDisplay: Don't ease allocation of clones

### DIFF
--- a/ui/appDisplay.js
+++ b/ui/appDisplay.js
@@ -172,6 +172,10 @@ function enable() {
 
         this._availWidth = availWidth;
         this._availHeight = availHeight;
+
+        // Disable easing allocation on clones
+        if (this !== Main.overview.viewSelector.appDisplay)
+            this._grid.layout_manager._pageSizeChanged = true;
     });
 
     Utils.override(AppDisplay.AppDisplay, 'goToPage',


### PR DESCRIPTION
Hijack the layout manager to think the adapted size
changed, which makes it skip the easing of the icon
allocation.

https://phabricator.endlessm.com/T31015