### PR TITLE
internetSearch: Use numbered placeholders

### DIFF
--- a/ui/internetSearch.js
+++ b/ui/internetSearch.js
@@ -216,10 +216,10 @@ var InternetSearchProvider = class {
                 const engineName = this._getEngineName();
 
                 if (engineName) {
-                    /* Translators: the first %s is the search engine name, and the second
+                    /* Translators: the first placeholder is the search engine name, and the second
                      * is the search string. For instance, 'Search Google for "hello"'.
                      */
-                    name = _('Search %s for "%s"').format(engineName, query);
+                    name = _('Search %1$s for "%2$s"').format(engineName, query);
                 } else {
                     name = _('Search the internet for "%s"').format(query);
                 }


### PR DESCRIPTION
I noticed today that the message:

    Search %s for "%s"

this string is translated into French as:

    Rechercher "%s" sur %s

or, back into English, as:

    Search "%s" on %s

That is, the sentence is rewritten to swap the placeholders. In
principal this is fine because the translator can use the POSIX
parameter field extension to explicitly select which parameter to use:

    Rechercher "%2$s" sur %1$s

However Transifex does not seem to support that. As a result the French
translation comes out as:

    Rechercher "Google" sur my search terms

rather than the intended:

    Rechercher "my search terms" sur Google

If I manually use the %2$s notation in the Transifex web editor, it gets
upset with me because this string does not appear in the source text.
So, let's try making it explicit.

https://phabricator.endlessm.com/T31245
