### PR TITLE
ui: Drop custom search entry text

### DIFF
--- a/ui/layout.js
+++ b/ui/layout.js
@@ -140,10 +140,6 @@ class OverviewClone extends St.BoxLayout {
         this.connect('destroy', this._onDestroy.bind(this));
     }
 
-    setSearchHint(hint) {
-        this._entry.hint_text = hint;
-    }
-
     vfunc_map() {
         super.vfunc_map();
         this._appDisplayClone._grid.queue_redraw();
@@ -237,15 +233,6 @@ var OverviewCloneController = class OverviewCloneController {
 };
 
 const cloneController = new OverviewCloneController();
-
-function setSearchHint(hint) {
-    bgGroups.forEach(group => {
-        if (!group._appGridClone)
-            return;
-
-        group._appGridClone.setSearchHint(hint);
-    });
-}
 
 function enable() {
     if (startupPreparedId === 0) {

--- a/ui/search.js
+++ b/ui/search.js
@@ -115,16 +115,6 @@ function registerInternetSearchProvider() {
         internetSearchProvider = provider;
 
         searchView._reloadRemoteProviders();
-
-        // Update the search entry text
-        const entry = Main.overview.searchEntry;
-        const searchEngine = InternetSearch.getSearchEngineName();
-        if (searchEngine)
-            entry.hint_text = _('Search %s and more…').format(searchEngine);
-        else
-            entry.hint_text = _('Search the internet and more…');
-
-        LayoutOverrides.setSearchHint(entry.hint_text);
     }
 }
 
@@ -137,10 +127,6 @@ function unregisterInternetSearchProvider() {
     internetSearchProvider = null;
 
     searchView._reloadRemoteProviders();
-
-    // Reset the search entry text
-    Main.overview.searchEntry.hint_text = _('Type to search');
-    LayoutOverrides.setSearchHint(_('Type to search'));
 }
 
 function setInternetSearchProviderEnable(enabled) {


### PR DESCRIPTION
Previously we customised the search entry to say ‘Search Google and
more…’, but this led users to believe the search entry was just for
searching the internet. In reality, it’s for searching everything,
including all the local content which is such a focus of Endless OS.

Stop customising the text and leave it at the default ‘Type to search’
as set by GNOME.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T31448