### PR TITLE
settings: Remove Hack Clubhouse special case

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -30,7 +30,6 @@ const ParentalControlsManager = imports.misc.parentalControlsManager;
 
 const CURRENT_VERSION = 1;
 const APP_CENTER_ID = 'org.gnome.Software.desktop';
-const CLUBHOUSE_ID = 'com.hack_computer.Clubhouse.desktop';
 
 function _getMigrationSettings() {
     const dir = DesktopExtension.dir.get_child('migration').get_path();
@@ -142,10 +141,6 @@ function _migrateToV1(migrationSettings, extensionSettings) {
 
     let index = 0;
     const addedItems = new Set();
-
-    // Add the clubhouse icon
-    _addIcon(pages, CLUBHOUSE_ID, index++, itemsPerPage);
-    addedItems.add(CLUBHOUSE_ID);
 
     for (const itemId of desktopIcons) {
         const isFolder = iconGridLayout.iconIsFolder(itemId);


### PR DESCRIPTION
This was introduced so that we could cause Hack to appear on the desktop
for existing users. (Changing the default grid layout would not have
done anything in that case.)

However, this special-case has several downsides:

- It is hard to put Hack somewhere else on the grid in a custom image.
  (As an implementation detail, it can be placed in a folder.)
- If Hack is not installed, or has been placed in a folder, a space is
  still reserved for it on the first page, so there is always a blank
  space there.

Remove this special case in favour of explicitly placing Hack in the
default icon grid layout. https://github.com/endlessm/eos-shell-content/pull/254

On existing systems which update to a version of Endless containing this
change, newly-created user accounts will likely *not* get Hack in the
first position on the desktop. This is because the vast majority of
Endless OS systems have a custom icon grid layout in
/var/lib/eos-image-defaults, and we do not have a mechanism to update
these files. We could implement such a mechanism but this edge case does
not seem worth the cost of doing so.

https://phabricator.endlessm.com/T32556
