### PR TITLE
Force hide overview when activating app icons

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -25,6 +25,7 @@ const Layout = DesktopExtension.imports.ui.layout;
 const Overview = DesktopExtension.imports.ui.overview;
 const OverviewControls = DesktopExtension.imports.ui.overviewControls;
 const Panel = DesktopExtension.imports.ui.panel;
+const Search = DesktopExtension.imports.ui.search;
 const Settings = DesktopExtension.imports.settings;
 const Workspace = DesktopExtension.imports.ui.workspace;
 const WorkspaceMonitor = DesktopExtension.imports.ui.workspaceMonitor;
@@ -48,6 +49,7 @@ class Extension {
         Overview.enable(this._workspaceMonitor);
         OverviewControls.enable();
         Panel.enable();
+        Search.enable();
         Workspace.enable();
         this._workspaceMonitor.enable();
 
@@ -66,6 +68,7 @@ class Extension {
         Overview.disable();
         OverviewControls.disable();
         Panel.disable();
+        Search.disable();
         Workspace.disable();
 
         this._enabled = false;

--- a/ui/appDisplay.js
+++ b/ui/appDisplay.js
@@ -66,6 +66,13 @@ function enable() {
             this._grid.goToPage(pageNumber, animate);
         });
 
+    Utils.override(AppDisplay.AppIcon, 'activate', function (button) {
+        const original = Utils.original(AppDisplay.AppIcon, 'activate');
+        original.bind(this)(button);
+
+        Main.overview.hide(true);
+    });
+
     Utils.override(AppDisplay.PageManager, 'getAppPosition', function(appId) {
         const original = Utils.original(AppDisplay.PageManager, 'getAppPosition');
         let [page, position] = original.bind(this)(appId);
@@ -125,6 +132,7 @@ function enable() {
 
 function disable() {
     Utils.restore(AppDisplay.AppDisplay);
+    Utils.restore(AppDisplay.AppIcon);
     Utils.restore(AppDisplay.PageManager);
 
     Main.overview.disconnect(overviewHidingId);

--- a/ui/search.js
+++ b/ui/search.js
@@ -1,0 +1,38 @@
+/* exported enable, disable */
+/*
+ * Copyright 2022 Endless OS Foundation LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+const { Clutter, GObject, Graphene, Meta, Shell, St } = imports.gi;
+
+const ExtensionUtils = imports.misc.extensionUtils;
+const DesktopExtension = ExtensionUtils.getCurrentExtension();
+
+const Search = imports.ui.search;
+const Utils = DesktopExtension.imports.utils;
+
+function enable() {
+    Utils.override(Search.SearchResult, 'hide', function() {
+        const original = Utils.original(Search.SearchResult, 'activate');
+        original.bind(this)();
+
+        Main.overview.hide(true);
+    });
+}
+
+function disable() {
+    Utils.restore(Search.SearchResult);
+}


### PR DESCRIPTION
This includes search results. In this case, we want to
hide the overview even when no apps are open.

This change includes activating search results too - some
of which are app icons, others are list rows.

https://phabricator.endlessm.com/T33020