### PR TITLE
dash: Update barrier when monitor layout changes

### DIFF
--- a/ui/dash.js
+++ b/ui/dash.js
@@ -254,6 +254,7 @@ const Intellihide = GObject.registerClass({
             return;
 
         this._pressureBarrier.removeBarrier(this._barrier);
+        this._barrier.destroy();
         delete this._barrier;
     }
 

--- a/ui/dash.js
+++ b/ui/dash.js
@@ -293,6 +293,14 @@ const Intellihide = GObject.registerClass({
             this._armTriggerTimeout();
         });
         this._updateBarrier();
+
+        this._monitorsChangedId = Main.layoutManager.connect('monitors-changed', () => {
+            this._updateBarrier();
+        });
+
+        this._workareasChangedId = global.display.connect('workareas-changed', () => {
+            this._updateBarrier();
+        });
     }
 
     disable() {
@@ -302,6 +310,12 @@ const Intellihide = GObject.registerClass({
         this._removeBarrier();
         this._pressureBarrier.destroy()
         delete this._pressureBarrier;
+
+        Main.layoutManager.disconnect(this._monitorsChangedId);
+        delete this._monitorsChangedId;
+
+        global.display.disconnect(this._workareasChangedId);
+        delete this._workareasChangedId;
 
         this._disarmTriggerTimeout();
     }


### PR DESCRIPTION
We need to account that the monitor layout state when the extension
is enable may change, otherwise the cursor barrier can get stuck in
weird places.

Do that by accounting for Main.layoutManager's 'monitors-changed'
signal, and global.display's 'workareas-changed' signals. The
combination of these two signals is apparently enough to cover all
cases where the cursor barrier needs to be recalculated.

https://phabricator.endlessm.com/T33055