### PR TITLE
workspaceMonitor: Don't toggle overview before startup

### DIFF
--- a/ui/overview.js
+++ b/ui/overview.js
@@ -32,6 +32,13 @@ function enable(workspaceMonitor) {
         const original = Utils.original(Overview.Overview, 'hide');
         original.bind(this)();
     });
+
+    Utils.override(Overview.Overview, 'runStartupAnimation', async function(callback) {
+        const original = Utils.original(Overview.Overview, 'runStartupAnimation');
+        original.bind(this)(callback);
+
+        this._startupAnimationDone = true;
+    });
 }
 
 function disable() {

--- a/ui/workspaceMonitor.js
+++ b/ui/workspaceMonitor.js
@@ -46,6 +46,9 @@ class WorkspaceMonitor extends GObject.Object {
         if (!this._enabled)
             return;
 
+        if (!Main.overview._startupAnimationDone)
+            return;
+
         const windows = this._getVisibleWindows();
         if (windows.length === 0)
             Main.overview.showApps();


### PR DESCRIPTION
GNOME Shell enables extensions very early in the startup process,
after creating most of the main actor tree, but before actually
running the startup animation.

When the eos-desktop-extension is enabled, WorkspaceMonitor calls
_updateOverview(). During startup, naturally, there are no running
apps, so _updateOverview() ends up calling Main.overview.showApps().

Overview.showApps() then performs the regular overview routines,
and emits the Overview::showing signal. SearchController, which
is connected to this signal, reacts by connecting to the 'key-press'
event of global.stage:

```
        Main.overview.connect('showing', () => {
            this._stageKeyPressId =
                global.stage.connect('key-press-event', this._onStageKeyPress.bind(this));
        });
```

The problem is in the code above: notice that this callback
unconditionally connects to `key-press-event`, without ever
checking if it's already connected to it.

Anyway, back to startup.

After eos-desktop-extension doing all that, making Overview emit
'showing', and therefore making SearchController connect to the
stage's 'key-press-event', we start GNOME Shell's own startup
routines.

The Layout class calls into init(), which, after setting a few
variables up, calls Main.overview.runStartupAnimation().

Main.overview.runStartupAnimation() itself unconditionally, and
manually, emits the 'showing' and 'shown' signals. The 'showing'
signal, as explained above, reaches SearchController again and
makes it connect to the stage's 'key-press-event' signal. Again.

The first 'key-press-event' connection is leaked now.

SearchController now will always react twice to 'key-press-event',
which will call startSearch() and send synthetic events to the
search entry. These events roundtrip through ClutterInputFocus,
which asynchronously batches them into IBus.

On our side, the fix to this issue is simple: don't toggle the
Overview before it has started up.

There'll be robustness fixes upstream to avoid this situation,
but eos-desktop-extension should also be a good citizen and not
do potentially breaky actions.

https://phabricator.endlessm.com/T33000