### PR TITLE
Start session on app grid

### DIFF
--- a/ui/overview.js
+++ b/ui/overview.js
@@ -35,9 +35,10 @@ function enable(workspaceMonitor) {
 
     Utils.override(Overview.Overview, 'runStartupAnimation', async function(callback) {
         const original = Utils.original(Overview.Overview, 'runStartupAnimation');
-        original.bind(this)(callback);
-
-        this._startupAnimationDone = true;
+        original.bind(this)(() => {
+            callback();
+            this._startupAnimationDone = true;
+        });
     });
 }
 


### PR DESCRIPTION
From the main commit's message:

```
WorkspaceMonitor reacts to actors being added to, and
removed from, the window group. However - and this is
something me and Andre discussed years ago - this
approach can backfire when windows are added and removed
in quick succession.

So far we didn't have to deal with this case, but
recently, after fixing other bugs elsewhere in the
extension, Hack started to hit it.

Throttling updates is not a perfect solution by any
means, but it's certainly more robust than reacting
to every single actor addition and removal unconditionally.
```

https://phabricator.endlessm.com/T33294