### PR TITLE
Reuse translations from GNOME Shell where possible

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,14 +1,16 @@
 # List of source files to look for translatable strings.
 # Please keep this file sorted alphabetically.
 ui/appDisplay.js
+ui/appSystem.js
 ui/dash.js
 ui/iconGridLayout.js
 ui/internetSearch.js
-ui/keybindings.js
 ui/layout.js
+ui/overviewControls.js
 ui/overview.js
+ui/panel.js
 ui/search.js
-ui/viewSelector.js
+ui/workspace.js
 ui/workspaceMonitor.js
 settings.js
 utils.js

--- a/settings.js
+++ b/settings.js
@@ -21,7 +21,7 @@ const { Gio, GLib, Shell } = imports.gi;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const DesktopExtension = ExtensionUtils.getCurrentExtension();
-const _ = DesktopExtension.imports.utils.gettext;
+const GS_ = DesktopExtension.imports.utils.GS_;
 
 const AppDisplay = imports.ui.appDisplay;
 const IconGridLayout = DesktopExtension.imports.ui.iconGridLayout;
@@ -152,7 +152,7 @@ function _migrateToV1(migrationSettings, _extensionSettings) {
                 Shell.util_get_translated_folder_name(itemId);
 
             if (!translatedName)
-                translatedName = _('Unnamed Folder');
+                translatedName = GS_('Unnamed Folder');
 
             id = _createFolder(folderSettings, translatedName, folderIcons);
         } else if (!installedAppsSet.has(itemId)) {

--- a/ui/panel.js
+++ b/ui/panel.js
@@ -28,7 +28,7 @@ const Panel = imports.ui.panel;
 const PanelMenu = imports.ui.panelMenu;
 const Utils = DesktopExtension.imports.utils;
 
-const _ = Utils.gettext;
+const GS_ = Utils.GS_;
 
 const EosPanelButton = GObject.registerClass(
 class EosPanelButton extends PanelMenu.Button {
@@ -136,7 +136,7 @@ const ApplicationsButton = GObject.registerClass(
 class ApplicationsButton extends EosPanelButton {
     _init() {
         super._init({
-            text: _('Applications'),
+            text: GS_('Applications'),
             state: OverviewControls.ControlsState.APP_GRID,
             callback: () => {
                 if (!Main.overview.visible)
@@ -154,7 +154,7 @@ const WorkspacesButton = GObject.registerClass(
 class WorkspacesButton extends EosPanelButton {
     _init() {
         super._init({
-            text: _('Activities'),
+            text: GS_('Activities'),
             state: OverviewControls.ControlsState.WINDOW_PICKER,
             callback: () => {
                 if (!Main.overview.visible)

--- a/utils.js
+++ b/utils.js
@@ -8,6 +8,8 @@ const Gettext = imports.gettext.domain('eos-desktop-extension');
 
 var gettext = Gettext.gettext;
 
+var GS_ = imports.gettext.domain('gnome-shell').gettext;
+
 function override(object, methodName, callback) {
     if (!object._desktopFnOverrides)
         object._desktopFnOverrides = {};


### PR DESCRIPTION
These three strings are all present and translated into many languages in GNOME Shell itself. By accessing them from the 'gnome-shell' gettext domain, we can reuse those translations. By using this wrapper function that does not match the patterns passed to xgettext by meson, these strings will not be extracted for translation, saving on unnecessary work.

With this change, the only strings remaining in this module are for the internet search provider. (And actually, that code is no longer used, but that's the subject of another ticket!)

This is a bit of a hack but I think it's not an awful approach?

https://phabricator.endlessm.com/T33603

