### PR TITLE
layout: Do not create object in global scope

### DIFF
--- a/ui/layout.js
+++ b/ui/layout.js
@@ -217,9 +217,10 @@ var OverviewCloneController = class OverviewCloneController {
     }
 };
 
-const cloneController = new OverviewCloneController();
+let cloneController;
 
 function enable() {
+    cloneController = new OverviewCloneController();
     cloneController.enable();
 }
 


### PR DESCRIPTION
Objects should only be created in the enable phase of the extension life cycle.

https://phabricator.endlessm.com/T33660