### PR TITLE
overviewControls: Hide thumbnails when search is active

### DIFF
--- a/ui/overviewControls.js
+++ b/ui/overviewControls.js
@@ -254,6 +254,7 @@ function enable() {
             getWorkspaceThumbnailOpacityForState(initialState),
             getWorkspaceThumbnailOpacityForState(finalState),
             progress);
+        this._thumbnailsBox.visible = !searchActive;
     });
 
     Utils.override(OverviewControls.ControlsManager, 'runStartupAnimation', async function (callback) {


### PR DESCRIPTION
This is what GNOME Shell does in the overriden method. This should have been added since the beginning, and so far it worked out of luck, but after 7d6577321d422f the happy sequence of events we used to hit is no more.

https://phabricator.endlessm.com/T33972