### PR TITLE
Further workspace tweaks

### DIFF
--- a/stylesheet.scss
+++ b/stylesheet.scss
@@ -3,7 +3,19 @@
   border-width: solid 1px black;
 }
 
-.panel-button StLabel,
 .app-well-app .overview-icon-with-label StLabel {
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+}
+
+// Force opaque panel
+#panel {
+  &.login-screen,
+  &.unlock-screen,
+  &:overview {
+    background-color: #000;
+
+    .panel-corner {
+      -panel-corner-opacity: 1;
+    }
+  }
 }

--- a/ui/overviewControls.js
+++ b/ui/overviewControls.js
@@ -255,6 +255,33 @@ function enable() {
             getWorkspaceThumbnailOpacityForState(finalState),
             progress);
         this._thumbnailsBox.visible = !searchActive;
+
+        // Update the vignette effect
+        if (Main.overview._backgroundGroup) {
+            for (const background of Main.overview._backgroundGroup) {
+                const { content } = background;
+
+                const getVignetteForState = state => {
+                    switch (state) {
+                    case OverviewControls.ControlsState.HIDDEN:
+                        return [1.0, 0.0];
+                    case OverviewControls.ControlsState.WINDOW_PICKER:
+                        return [0.7, 0.5];
+                    case OverviewControls.ControlsState.APP_GRID:
+                        return [1.0, 0.0];
+                    }
+                };
+
+                const initial = getVignetteForState(initialState);
+                const final = getVignetteForState(finalState);
+
+                content.set_vignette(true, ...[
+                    ShellUtils.lerp(initial[0], final[0], progress),
+                    ShellUtils.lerp(initial[1], final[1], progress),
+                ]);
+            }
+        }
+
     });
 
     Utils.override(OverviewControls.ControlsManager, 'runStartupAnimation', async function (callback) {

--- a/ui/workspace.js
+++ b/ui/workspace.js
@@ -50,18 +50,6 @@ function getOpacityForState(state) {
     return 0.0;
 }
 
-function getShadowOpacityForState(state) {
-    switch (state) {
-    case OverviewControls.ControlsState.HIDDEN:
-        return 0.0;
-    case OverviewControls.ControlsState.WINDOW_PICKER:
-        return 0.5;
-    case OverviewControls.ControlsState.APP_GRID:
-        return 0.0;
-    }
-
-    return 0.0;
-}
 
 function enable() {
     Utils.override(Workspace.Workspace, '_init', function(metaWorkspace, monitorIndex, overviewAdjustment) {
@@ -74,14 +62,11 @@ function enable() {
             const { initialState, finalState, progress } =
                 overviewAdjustment.getStateTransitionParams();
 
-            const shadowOpacity = ShellUtils.lerp(
-                getShadowOpacityForState(initialState),
-                getShadowOpacityForState(finalState),
-                progress);
             const opacity = ShellUtils.lerp(
                 getOpacityForState(initialState),
                 getOpacityForState(finalState),
                 progress);
+            const borderOpacity = opacity * 5;
             const radius = ShellUtils.lerp(
                 getBorderRadiusForState(initialState),
                 getBorderRadiusForState(finalState),
@@ -89,7 +74,7 @@ function enable() {
 
             this.style = `
                 background-color: rgba(255, 255, 255, ${opacity});
-                box-shadow: 0 4px 30px rgba(0, 0, 0, ${shadowOpacity});
+                border: 1px solid rgba(127, 127, 127, ${borderOpacity});
                 border-radius: ${radius}px;
             `;
         });


### PR DESCRIPTION
Sadly `box-shadow` is not viable, so we will try returning to darkening the background in the overview state only, and using this plus a border around the workspace rounded-rectangle to give a crude simulacrum of depth.

I also tried making the top panel always opaque. I think it looks better this way.

New wallpaper from https://github.com/endlessm/eos-media/pull/54:

![Screenshot from 2022-11-11 11-27-34](https://user-images.githubusercontent.com/86760/201347275-a51eecc1-a8ce-45c3-a16b-4fff3c321136.png)

A light wallpaper I used a few weeks ago:

![Screenshot from 2022-11-11 11-28-03](https://user-images.githubusercontent.com/86760/201347286-3837b0b5-03b2-4ed0-ab6e-68a7f0f18e58.png)


https://phabricator.endlessm.com/T33971