### PR TITLE
Embolden font and sharpen shadow on app grid labels

### DIFF
--- a/stylesheet.scss
+++ b/stylesheet.scss
@@ -4,7 +4,8 @@
 }
 
 .app-well-app .overview-icon-with-label StLabel {
-  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+  font-weight: bold;
+  text-shadow: black 0px 2px 2px;
 }
 
 // Force opaque panel

--- a/ui/overviewControls.js
+++ b/ui/overviewControls.js
@@ -266,7 +266,7 @@ function enable() {
                     case OverviewControls.ControlsState.HIDDEN:
                         return [1.0, 0.0];
                     case OverviewControls.ControlsState.WINDOW_PICKER:
-                        return [0.7, 0.5];
+                        return [1.0, 0.5];
                     case OverviewControls.ControlsState.APP_GRID:
                         return [1.0, 0.0];
                     }

--- a/ui/workspace.js
+++ b/ui/workspace.js
@@ -42,7 +42,7 @@ function getOpacityForState(state) {
     case OverviewControls.ControlsState.HIDDEN:
         return 0.0;
     case OverviewControls.ControlsState.WINDOW_PICKER:
-        return 0.1;
+        return 0.2;
     case OverviewControls.ControlsState.APP_GRID:
         return 0.0;
     }
@@ -50,6 +50,18 @@ function getOpacityForState(state) {
     return 0.0;
 }
 
+function getBorderOpacityForState(state) {
+    switch (state) {
+    case OverviewControls.ControlsState.HIDDEN:
+        return 0.0;
+    case OverviewControls.ControlsState.WINDOW_PICKER:
+        return 0.3;
+    case OverviewControls.ControlsState.APP_GRID:
+        return 0.0;
+    }
+
+    return 0.0;
+}
 
 function enable() {
     Utils.override(Workspace.Workspace, '_init', function(metaWorkspace, monitorIndex, overviewAdjustment) {
@@ -66,7 +78,10 @@ function enable() {
                 getOpacityForState(initialState),
                 getOpacityForState(finalState),
                 progress);
-            const borderOpacity = opacity * 5;
+            const borderOpacity = ShellUtils.lerp(
+                getBorderOpacityForState(initialState),
+                getBorderOpacityForState(finalState),
+                progress);
             const radius = ShellUtils.lerp(
                 getBorderRadiusForState(initialState),
                 getBorderRadiusForState(finalState),
@@ -74,7 +89,7 @@ function enable() {
 
             this.style = `
                 background-color: rgba(255, 255, 255, ${opacity});
-                border: 1px solid rgba(127, 127, 127, ${borderOpacity});
+                border: 1px solid rgba(0, 0, 0, ${borderOpacity});
                 border-radius: ${radius}px;
             `;
         });


### PR DESCRIPTION
Prior to this commit, the font was at regular weight, with a 1px vertical offset, 3px radius and 60% opacity black shadow.

Embolden the font & make the shadow opaque black, with a 2px vertical offset and 2px radius. This matches the settings we had on EOS 4 and makes the app grid legible against the wallpaper now that we have stopped darkening it.

![Screenshot from 2022-11-17 13-53-56](https://user-images.githubusercontent.com/86760/202465331-b17d1c0f-c29a-4b7c-be2c-f787b8e1d0fa.png)
![Screenshot from 2022-11-17 13-53-52](https://user-images.githubusercontent.com/86760/202465343-3b5e84d9-c25a-4a3c-8ccc-b5bebb47e81e.png)


https://phabricator.endlessm.com/T34129