### PR TITLE
Move the dash closer to the bottom of the screen

### DIFF
--- a/stylesheet.scss
+++ b/stylesheet.scss
@@ -28,3 +28,21 @@
     }
   }
 }
+
+/* Copied from GNOME Shell */
+$base_padding: 6px;
+$dash_padding: $base_padding + 4px; // 10px
+/* Modified here */
+$dash_bottom_margin: 8px;
+
+.dash-background {
+  margin-bottom: $dash_bottom_margin;
+}
+
+.dash-item-container .app-well-app, .show-apps {
+  padding-bottom: $dash_padding + $dash_bottom_margin;
+}
+
+.dash-separator {
+  margin-bottom: $dash_bottom_margin;
+}


### PR DESCRIPTION
In Shell, $dash_bottom_margin is 16px. Joana's feeling is that,
particularly in our design, this is too wide. 8px is deemed to feel
right.

These are the three rules in _dash.scss from gnome-shell, plus the
variables that they need. (I'm overriding only 'margin-bottom', rather
than the full 'margin' rule.)

https://phabricator.endlessm.com/T33379
