### PR TITLE
panel: Clear indicators array after disposing each element

### DIFF
--- a/ui/panel.js
+++ b/ui/panel.js
@@ -194,5 +194,6 @@ function enable() {
 function disable() {
     for (const indicator of indicators)
         indicator.destroy();
+    indicators.splice(0, indicators.length);
     setActivitiesButtonVisible(true);
 }


### PR DESCRIPTION
When the extension is `enable()`d, two objects are added to
`indicators`.  When `disable()`d, `.destroy()` is called on each element
of `indicators`. But the objects are never removed from `indicators`. So
each subsequent time the extension is enabled and disabled, `.destroy()`
is called on two more already-disposed objects:

    Object .Gjs_ui_panel_WorkspacesButton (0x560a39af9db0), has been already disposed — impossible to access it. This might be caused by the object having been destroyed from C code using something such as destroy(), dispose(), or remove() vfuncs.
    == Stack trace for context 0x560a35b0d200 ==
    #0   560a4c3a3c20 i   /usr/share/gnome-shell/extensions/eos-desktop@endlessm.com/ui/panel.js:196 (28fc36e111a0 @ 87)
    #1   560a4c3a3b90 i   /usr/share/gnome-shell/extensions/eos-desktop@endlessm.com/extension.js:68 (d4d050a6c90 @ 145)
    #2   7fffce8b8b80 b   resource:///org/gnome/shell/ui/extensionSystem.js:108 (230a9ff6cba0 @ 395)
    #3   7fffce8b8c30 b   resource:///org/gnome/shell/ui/extensionSystem.js:621 (230a9ff5cf10 @ 15)
    #4   7fffce8b8d30 b   self-hosted:225 (36ef621da290 @ 273)
    #5   560a4c3a3b00 i   resource:///org/gnome/shell/ui/extensionSystem.js:620 (230a9ff5cf60 @ 98)
    #6   560a4c3a3a70 i   resource:///org/gnome/shell/ui/extensionSystem.js:638 (230a9ff5cec0 @ 82)
    #7   7fffce8b9890 b   self-hosted:850 (36ef621b09c0 @ 423)
    #8   7fffce8b9980 b   resource:///org/gnome/gjs/modules/core/_signals.js:114 (36ef621da380 @ 439)
    #9   7fffce8ba120 b   resource:///org/gnome/shell/ui/sessionMode.js:213 (35a498517d80 @ 284)
    #10   560a4c3a3910 i   resource:///org/gnome/shell/ui/sessionMode.js:174 (35a498517ec0 @ 40)
    #11   560a4c3a3848 i   resource:///org/gnome/shell/ui/screenShield.js:677 (35a498504790 @ 330)
    #12   560a4c3a3780 i   resource:///org/gnome/shell/ui/screenShield.js:734 (35a498504740 @ 440)
    #13   560a4c3a36e8 i   resource:///org/gnome/shell/ui/shellDBus.js:500 (35a498509e70 @ 67)
    #14   560a4c3a3600 i   resource:///org/gnome/gjs/modules/core/overrides/Gio.js:354 (36ef621d8740 @ 955)
    #15   560a4c3a3548 i   resource:///org/gnome/gjs/modules/core/overrides/Gio.js:387 (36ef621d8600 @ 34)

In particular, locking the screen disables all extensions, and unlocking
enables them again. So the nth time you lock the screen, this backtrace
is logged 2*(n-1) times.

Fix this by emptying the array after its elements are destroyed.

https://phabricator.endlessm.com/T34481
