### PR TITLE
Log errors from async enable function

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -34,7 +34,7 @@ class Extension {
         this._enabled = false;
     }
 
-    async enable() {
+    async _enable() {
         if (this._enabled)
             return;
 
@@ -53,6 +53,12 @@ class Extension {
         this._workspaceMonitor.enable();
 
         this._enabled = true;
+    }
+
+    enable() {
+        this._enable().catch((error) => {
+            logError(error);
+        });
     }
 
     disable() {


### PR DESCRIPTION
Previously the Extension.enable() function was declared 'async'. This
means that it returns a promise, which resolves or rejects some time
later, rather than raising an exception synchronously.

However GNOME Shell does not treat the return value of enable() as a
promise. It only catches exceptions synchronously.

So if an exception occurred, rather than logging any useful output, we
would see:

    Unhandled promise rejection. To suppress this warning, add an error
    handler to your promise chain with .catch() or a try-catch block
    around your await expression. Stack trace of the failed promise:
      enable@/usr/share/gnome-shell/extensions/eos-desktop@endlessm.com/extension.js:37:1
      _callExtensionEnable@resource:///org/gnome/shell/ui/extensionSystem.js:169:32
      loadExtension@resource:///org/gnome/shell/ui/extensionSystem.js:368:26
      _loadExtensions/<@resource:///org/gnome/shell/ui/extensionSystem.js:622:18
      collectFromDatadirs@resource:///org/gnome/shell/misc/fileUtils.js:27:28
      _loadExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:597:19
      _enableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:631:18
      _sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:662:18
      init@resource:///org/gnome/shell/ui/extensionSystem.js:57:14
      _initializeUI@resource:///org/gnome/shell/ui/main.js:276:22
      start@resource:///org/gnome/shell/ui/main.js:166:5
      @resource:///org/gnome/shell/ui/init.js:6:17

Move the async-ness to an internal _enable() function; make enable()
a regular function, and explicitly catch & log errors raised
asynchronously by _enable().

https://phabricator.endlessm.com/T34672
