### PR TITLE
settings: Remove Software/App Center special-case

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -29,7 +29,6 @@ const Main = imports.ui.main;
 const ParentalControlsManager = imports.misc.parentalControlsManager;
 
 const CURRENT_VERSION = 1;
-const APP_CENTER_ID = 'org.gnome.Software.desktop';
 
 function _getMigrationSettings() {
     const dir = DesktopExtension.dir.get_child('migration').get_path();
@@ -159,21 +158,8 @@ function _migrateToV1(migrationSettings, _extensionSettings) {
             continue;
         }
 
-        // If we have more than 24 icons, make sure that the app center icon
-        // appended to the first page
-        if (index === itemsPerPage - 1) {
-            _addIcon(pages, APP_CENTER_ID, index++, itemsPerPage);
-            addedItems.add(APP_CENTER_ID);
-        }
-
         _addIcon(pages, id, index++, itemsPerPage);
         addedItems.add(itemId);
-    }
-
-    // Append the app center icon if it wasn't added in the loop above
-    if (!addedItems.has(APP_CENTER_ID)) {
-        _addIcon(pages, APP_CENTER_ID, index++, itemsPerPage);
-        addedItems.add(APP_CENTER_ID);
     }
 
     // Switch to the next page


### PR DESCRIPTION
This effectively reverts 85252df74fec2b455afd54a5abb21c894447b814
"migration: Append app center icon to migrated icons" and
f60de8b8def292cb82937076e1c9cd0110aa3302 "settings: Append the app
center icon at the first page".

Since Endless OS 5, which includes GNOME 41, an app cannot be on both
the dash and in the app grid, and the dash takes precedence. The App
Center is on the dash by default. As a result, this code reserves space
on the first page of the app grid for App Center, but it doesn't
actually appear there.

I consulted with Joana on whether App Center should live in the grid or
the dock:

> The dock should hold the main apps, the App Center should be treated
> like that I think.

Remove this special-case. It does mean it is impossible to implement
"Place the App Center at the end of the first page of the grid" by
customizing the favourites and the layout (because the layout JSON
doesn't include pagination) but we just won't do that.

https://phabricator.endlessm.com/T34646
