### PR TITLE
Support GNOME 43

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Provides the signature Endless OS desktop experience atop GNOME Shell 41 or 42.
 
 ## Install
 
-Compatible with GNOME 41 and 42.
+Compatible with GNOME 43.
 
 This extension is distributed via [extensions.gnome.org](https://extensions.gnome.org/extension/5419/endless-desktop/); head there or use the excellent [Extension Manager](https://flathub.org/apps/details/com.mattjakeman.ExtensionManager) to install it.

--- a/metadata.json.in
+++ b/metadata.json.in
@@ -3,6 +3,6 @@
 "name": "Endless Desktop",
 "description": "Endless OS signature desktop",
 "settings-schema": "@settings_schema@",
-"shell-version": ["41", "42"],
+"shell-version": ["43"],
 "url": "https://github.com/endlessm/eos-desktop-extension"
 }

--- a/ui/appDisplay.js
+++ b/ui/appDisplay.js
@@ -48,22 +48,12 @@ let hidingOverview = false;
 function enable() {
     Utils.override(AppDisplay.AppDisplay, 'goToPage',
         function (pageNumber, animate = true) {
+            const original = Utils.original(AppDisplay.AppDisplay, 'goToPage');
+
             if (hidingOverview)
                 return;
 
-            pageNumber = Math.clamp(pageNumber, 0, this._grid.nPages - 1);
-
-            if (this._grid.currentPage === pageNumber &&
-                this._displayingDialog &&
-                this._currentDialog)
-                return;
-            if (this._displayingDialog && this._currentDialog)
-                this._currentDialog.popdown();
-
-            if (this._grid.currentPage === pageNumber)
-                return;
-
-            this._grid.goToPage(pageNumber, animate);
+            original.bind(this)(pageNumber, animate);
         });
 
     Utils.override(AppDisplay.AppIcon, 'activate', function (button) {

--- a/ui/internetSearch.js
+++ b/ui/internetSearch.js
@@ -205,7 +205,7 @@ var InternetSearchProvider = class {
         }
     }
 
-    getResultMetas(results, callback) {
+    async getResultMetas(results) {
         const metas = results.map(resultId => {
             let name;
             if (resultId.startsWith('uri:')) {
@@ -235,14 +235,14 @@ var InternetSearchProvider = class {
                 },
             };
         });
-        callback(metas);
+        return metas;
     }
 
     filterResults(results, maxNumber) {
         return results.slice(0, maxNumber);
     }
 
-    getInitialResultSet(terms, callback, _cancellable) {
+    async getInitialResultSet(terms, _cancellable) {
         const results = [];
 
         if (this._networkMonitor.network_available) {
@@ -254,11 +254,11 @@ var InternetSearchProvider = class {
                 results.push('search:%s'.format(query));
         }
 
-        callback(results);
+        return results;
     }
 
-    getSubsearchResultSet(previousResults, terms, callback, cancellable) {
-        this.getInitialResultSet(terms, callback, cancellable);
+    async getSubsearchResultSet(previousResults, terms, cancellable) {
+        return this.getInitialResultSet(terms, cancellable);
     }
 
     activateResult(metaId) {


### PR DESCRIPTION
A small set of changes to get `eos-desktop-extension` working reasonably well with GNOME 43.

https://phabricator.endlessm.com/T35078