### PR TITLE
panel: Clean up transitions between UI modes

### DIFF
--- a/ui/dash.js
+++ b/ui/dash.js
@@ -498,6 +498,10 @@ const EosDashController = class EosDashController {
         // Show the overview when the toggling the apps button in session
         // mode
         const { showAppsButton } = Main.overview.dash;
+        this._showAppsButtonClickedId = showAppsButton.connect('clicked', () => {
+            if (!showAppsButton.checked)
+                Main.overview._eosHideOrShowOverview();
+        });
         this._showOverviewId = showAppsButton.connect('notify::checked', () => {
             const { controls } = Main.overview._overview;
 
@@ -526,6 +530,9 @@ const EosDashController = class EosDashController {
         delete this._overviewSignals;
 
         this._intellihide.disable();
+
+        Main.overview.dash.showAppsButton.disconnect(this._showAppsButtonClickedId);
+        delete this._showAppsButtonClickedId;
 
         Main.overview.dash.showAppsButton.disconnect(this._showOverviewId);
         delete this._showOverviewId;

--- a/ui/overview.js
+++ b/ui/overview.js
@@ -68,11 +68,27 @@ function removeBackgroundFromOverview() {
 
 function enable(workspaceMonitor) {
     Utils.override(Overview.Overview, 'hide', function(bypassVisibleWindowCheck = false) {
-        if (!bypassVisibleWindowCheck && !workspaceMonitor.hasVisibleWindows)
+        if (!bypassVisibleWindowCheck && !workspaceMonitor.hasVisibleWindows) {
+            Main.overview.dash.showAppsButton.checked = true;
             return;
+        }
 
         const original = Utils.original(Overview.Overview, 'hide');
         original.bind(this)();
+    });
+
+    Utils.override(Overview.Overview, '_eosHideOrShowApps', function() {
+        if (workspaceMonitor.hasVisibleWindows)
+            this.hide();
+        else
+            Main.overview.dash.showAppsButton.checked = true;
+    });
+
+    Utils.override(Overview.Overview, '_eosHideOrShowOverview', function() {
+        if (workspaceMonitor.hasVisibleWindows)
+            this.hide();
+        else
+            Main.overview.dash.showAppsButton.checked = false;
     });
 
     Utils.override(Overview.Overview, 'runStartupAnimation', async function(callback) {

--- a/ui/panel.js
+++ b/ui/panel.js
@@ -144,12 +144,9 @@ class ApplicationsButton extends EosPanelButton {
             text: GS_('Applications'),
             state: OverviewControls.ControlsState.APP_GRID,
             callback: () => {
-                if (!Main.overview.visible)
-                    Main.overview.showApps();
-                else if (!Main.overview.dash.showAppsButton.checked)
-                    Main.overview.dash.showAppsButton.checked = true;
-                else
-                    Main.overview.hide();
+                Main.overview.dash.showAppsButton.checked = !Main.overview.dash.showAppsButton.checked;
+                if (!Main.overview.dash.showAppsButton.checked)
+                    Main.overview._eosHideOrShowOverview();
             },
         });
     }
@@ -167,7 +164,7 @@ class WorkspacesButton extends EosPanelButton {
                 else if (Main.overview.dash.showAppsButton.checked)
                     Main.overview.dash.showAppsButton.checked = false;
                 else
-                    Main.overview.hide();
+                    Main.overview._eosHideOrShowApps();
             },
         });
     }


### PR DESCRIPTION
With this change, clicking the Activities button while the Activities overview is active will consistently exit that mode in one of two fashions. If any windows are open, it will show those windows. If not, the shell will switch to the Applications grid.

In addition, the "Show Apps" button in the dash now behaves consistently with the "Applications" button in the panel. Clicking it when the Applications grid is visible will show either the current open windows, or the overview.

https://phabricator.endlessm.com/T35108