### PR TITLE
Revert "style: Modify dash style to match GNOME 41"

### DIFF
--- a/stylesheet.scss
+++ b/stylesheet.scss
@@ -14,17 +14,7 @@ $fg_color: if($variant == 'light', transparentize(black, .2), white);
 $panel_bg_color: #000;
 $panel_fg_color: if($variant == 'light', lighten($bg_color, 10%), darken($fg_color, 5%));
 
-// From GNOME Shell 41:
-// <https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/gnome-41/data/theme/gnome-shell-sass/widgets/_dash.scss>
 $base_padding: 6px;
-$base_margin: 4px;
-$base_border_radius: 8px;
-$modal_radius: $base_border_radius * 2;
-$dash_background_color: #3b3b3b;
-$dash_padding: $base_padding + 4px;
-$dash_spacing: $base_padding / 4;
-$dash_bottom_margin: $base_margin * 4;
-$dash_border_radius: $modal_radius * 1.5;
 
 .window-picker {
   background-color: rgba(0, 0, 0, 0.0);
@@ -90,32 +80,3 @@ $dash_border_radius: $modal_radius * 1.5;
     }
   }
 }
-
-#dash {
-  padding: 0 $dash_padding;
-
-  .overview-icon {
-    padding: $dash_padding / 2;
-  }
-}
-
-.dash-background {
-  background-color: $dash_background_color;
-  margin-bottom: $dash_bottom_margin;
-  padding: $dash_padding;
-  border-radius: $dash_border_radius;
-}
-
-// Dash Items
-.dash-item-container .app-well-app, .show-apps {
-  padding: $dash_padding $dash_spacing $dash_padding + $dash_bottom_margin;
-}
-
-.dash-separator {
-  margin: 0 ($dash_spacing + ($dash_padding / 2)) $dash_bottom_margin;
-}
-
-.dash-label {
-  padding: $base_padding $base_padding * 2;
-}
-


### PR DESCRIPTION
This reverts commit f6604eb6b24edf2b527ba7c80a396c4d09b65458.

These changes were causing a crash on lock / unlock, and some unnoticed alignment issues.

https://phabricator.endlessm.com/T35108