### PR TITLE
search: Fix the overview staying open on activate

### DIFF
--- a/ui/search.js
+++ b/ui/search.js
@@ -95,11 +95,22 @@ function setInternetSearchProviderEnable(enabled) {
 }
 
 function enable() {
-    Utils.override(Search.SearchResult, 'hide', function () {
+    Utils.override(Search.SearchResult, 'activate', function () {
         const original = Utils.original(Search.SearchResult, 'activate');
         original.bind(this)();
-
+        // The original activate() calls Main.overview.toggle(), which hides
+        // the overview, but (due to our customizations in overview.js) only if
+        // windows are visible. We expect a window to appear whenever a search
+        // result is activated, so we will force the overview to hide.
         Main.overview.hide(true);
+    });
+
+    Utils.override(Search.ListSearchResults, '_init', function (provider, resultsView) {
+        const original = Utils.original(Search.ListSearchResults, '_init');
+        original.bind(this)(provider, resultsView);
+        this.providerInfo.connect('clicked', () => {
+            Main.overview.hide(true);
+        });
     });
 
     setInternetSearchProviderEnable(true);


### PR DESCRIPTION
In 2b1f80d6d184994e35798357a7153902f974cba0, we added code to force the overview to hide when a search result is activated. However, this was incorrectly overriding a (nonexistent) `hide()` function in `Search.SearchResult`. As a result, we have bene using the default behaviour the `activate()` function. It calls `Main.overview.toggle()`, which hides the overview as long as at least one window is visible, giving the illusion that it was working as expected.

Instead, override `activate()` and force the overview to hide even if there are no windows visible at the moment. In addition, provide the same treatment for the signal handler which runs when a search provider is clicked.

https://phabricator.endlessm.com/T35132