### PR TITLE
search: Restore ListSearchResults when disabled

### DIFF
--- a/ui/search.js
+++ b/ui/search.js
@@ -118,5 +118,6 @@ function enable() {
 
 function disable() {
     Utils.restore(Search.SearchResult);
+    Utils.restore(Search.ListSearchResults);
     setInternetSearchProviderEnable(false);
 }


### PR DESCRIPTION
81131dc29db09e246d36ec9f4b8515e5f9860d46 (“search: Fix the overview
staying open on activate”) added an override of a method of
Search.ListSearchResults in `enable()` but did not remove it in
`disable()`.

In particular, the extension is disabled whenever the screen is locked,
and reënabled when it is unlocked, leading to infinite recursion in the
overridden ListSearchResults._init() method when it attempts to chain up
to the original implementation.

https://phabricator.endlessm.com/T35132
