### PR TITLE
Fix Shell input when startup animation interrupted

### DIFF
--- a/ui/dash.js
+++ b/ui/dash.js
@@ -34,6 +34,14 @@ const WINDOW_OVERLAP_POLL_TIMEOUT = 200;
 // Note: must be kept in sync with js/ui/overviewControls.js
 const DASH_MAX_HEIGHT_RATIO = 0.15;
 
+/**
+ * EosDashIcon:
+ * @app: a ShellApp
+ *
+ * Overrides DashIcon in order to notify the app's windows of where they should
+ * minimize to. (In vanilla Shell, windows minimize to the top-left corner of
+ * the screen because minimize is alleged not to exist.)
+ */
 const EosDashIcon = GObject.registerClass({
     GTypeName: 'EosDashIcon',
 }, class EosDashIcon extends Dash.DashIcon {
@@ -545,6 +553,9 @@ const EosDashController = class EosDashController {
 
 let dashController = null;
 function enable() {
+    /* Copy-pasted from Shell's dash.js, in order to replace 'new DashIcon'
+     * with 'new EosDashIcon'.
+     */
     Utils.override(Dash.Dash, '_createAppItem', function(app) {
         const appIcon = new EosDashIcon(app);
 
@@ -566,6 +577,11 @@ function enable() {
         return item;
     });
 
+    /* Not used by Shell itself. Intended for use in Looking Glass to experiment
+     * with different parameters:
+     *
+     * Main.overview.dash.setBarrierParams(..., ...)
+     */
     Utils.override(Dash.Dash, 'setBarrierParams', function(distance, time) {
         if (!dashController)
             return;

--- a/ui/overviewControls.js
+++ b/ui/overviewControls.js
@@ -372,7 +372,12 @@ function enable() {
             delay: STARTUP_ANIMATION_TIME,
             duration: STARTUP_ANIMATION_TIME,
             mode: Clutter.AnimationMode.EASE_OUT_QUAD,
-            onComplete: () => callback(),
+            onStopped: (isFinished) => {
+                if (!isFinished)
+                    this.dash.translation_y = 0;
+
+                callback();
+            }
         });
     });
 


### PR DESCRIPTION
During Shell's startup animation, an invisible “cover pane” actor is
placed over the entire screen:

    // During the initial transition, add a simple actor to block all events,
    // so they don't get delivered to X11 windows that have been transformed.

It is removed by the callback passed to
OverviewControls.ControlsManager.runStartupAnimation(), or in our case
the overridden version of it.

Previously, that callback was called from the onComplete() callback for
the ease() transition that slides the dock onto the screen. However it
is possible for a transition to be interrupted before it is complete. In
that case the onStopped() callback passed to ease() will be called (with
argument `false`) but onComplete() will not be.

In this extension, WorkspaceMonitor will trigger a switch out of the
overview if a new window is opened. When this happens,
EosDashController._addDashToSession() is called, which removes the dash
actor from the OverviewControls.ControlsManager and adds it to the
SessionDashContainer that we add to the session.

clutter_actor_remove_child() causes any outstanding transitions on the
child actor being removed to be stopped.

Taken all together, this means that if a window appears while the
startup animation is running, then the callback that removes the
invisible actor that blocks all input would never be called due to the
transition being interrupted before it completes.

Fix this by calling the runStartupAnimation() callback from an onStopped
callback, which is called when the transition either finishes normally
or is interrupted (with a boolean parameter indicating which is the
case).

This is essentially the same bug and fix as
https://github.com/endlessm/gnome-shell/commit/e69da36095d5093c1c7bec7a9c96c079c0b837f9.
This code is copy-pasted from gnome-shell and the same bug still exists
there; the difference is that, in regular Shell, the overview doesn't
get spontaneously closed during the startup animation so this case
cannot occur.

Then, if the window that caused the overview to be closed does not
happen to intersect the dash, then the dash would get stuck at whatever
point of the animation it had reached when it was interrupted. When the
dash is animated up and down by this extension (based on the decisions
of the Intellihide class) this case is handled by setting the
translation_y property directly when the transition is interrupted.

As far as Intellihide is concerned, there is no change to the
dash-visible property: while the overview was displayed, the dash should
be visible, and after the window appears, not intersecting the dash, and
the overview is closed, then the dash should be visible. So nothing
animates the dash.

Address this with similar logic in the startup animation's onStopped
callback: if the animation was interrupted, set the position directly.

https://phabricator.endlessm.com/T34453