### PR TITLE
Don't try to show app grid during startup animation

### DIFF
--- a/ui/appDisplay.js
+++ b/ui/appDisplay.js
@@ -46,8 +46,8 @@ let overviewHiddenId = 0;
 let hidingOverview = false;
 
 function enable() {
-    Utils.override(AppDisplay.AppDisplay, 'goToPage',
-        function (pageNumber, animate = true) {
+    Utils.override(AppDisplay.AppDisplay,
+        function goToPage(pageNumber, animate = true) {
             const original = Utils.original(AppDisplay.AppDisplay, 'goToPage');
 
             if (hidingOverview)
@@ -56,14 +56,14 @@ function enable() {
             original.call(this, pageNumber, animate);
         });
 
-    Utils.override(AppDisplay.AppIcon, 'activate', function (button) {
+    Utils.override(AppDisplay.AppIcon, function activate(button) {
         const original = Utils.original(AppDisplay.AppIcon, 'activate');
         original.call(this, button);
 
         Main.overview.hide(true);
     });
 
-    Utils.override(AppDisplay.PageManager, 'getAppPosition', function(appId) {
+    Utils.override(AppDisplay.PageManager, function getAppPosition(appId) {
         const original = Utils.original(AppDisplay.PageManager, 'getAppPosition');
         let [page, position] = original.call(this, appId);
         if (page != -1 || position != -1)

--- a/ui/appDisplay.js
+++ b/ui/appDisplay.js
@@ -53,19 +53,19 @@ function enable() {
             if (hidingOverview)
                 return;
 
-            original.bind(this)(pageNumber, animate);
+            original.call(this, pageNumber, animate);
         });
 
     Utils.override(AppDisplay.AppIcon, 'activate', function (button) {
         const original = Utils.original(AppDisplay.AppIcon, 'activate');
-        original.bind(this)(button);
+        original.call(this, button);
 
         Main.overview.hide(true);
     });
 
     Utils.override(AppDisplay.PageManager, 'getAppPosition', function(appId) {
         const original = Utils.original(AppDisplay.PageManager, 'getAppPosition');
-        let [page, position] = original.bind(this)(appId);
+        let [page, position] = original.call(this, appId);
         if (page != -1 || position != -1)
             return [page, position];
 
@@ -94,7 +94,7 @@ function enable() {
                 // is renamed from AppB which is renamed from AppC... we would stop
                 // searching at AppB (as the AppSystem.lookup_alias() impl
                 // currently does)
-                [page, position] = original.bind(this)(renamedFromId);
+                [page, position] = original.call(this, renamedFromId);
                 if (page != -1 || position != -1)
                     break;
             }

--- a/ui/dash.js
+++ b/ui/dash.js
@@ -556,7 +556,7 @@ function enable() {
     /* Copy-pasted from Shell's dash.js, in order to replace 'new DashIcon'
      * with 'new EosDashIcon'.
      */
-    Utils.override(Dash.Dash, '_createAppItem', function(app) {
+    Utils.override(Dash.Dash, function _createAppItem(app) {
         const appIcon = new EosDashIcon(app);
 
         appIcon.connect('menu-state-changed', (o, opened) => {
@@ -582,7 +582,7 @@ function enable() {
      *
      * Main.overview.dash.setBarrierParams(..., ...)
      */
-    Utils.override(Dash.Dash, 'setBarrierParams', function(distance, time) {
+    Utils.override(Dash.Dash, function setBarrierParams(distance, time) {
         if (!dashController)
             return;
 

--- a/ui/overview.js
+++ b/ui/overview.js
@@ -67,7 +67,7 @@ function removeBackgroundFromOverview() {
 }
 
 function enable(workspaceMonitor) {
-    Utils.override(Overview.Overview, 'hide', function(bypassVisibleWindowCheck = false) {
+    Utils.override(Overview.Overview, function hide(bypassVisibleWindowCheck = false) {
         if (!bypassVisibleWindowCheck && !workspaceMonitor.hasVisibleWindows) {
             Main.overview.dash.showAppsButton.checked = true;
             return;
@@ -77,21 +77,21 @@ function enable(workspaceMonitor) {
         original.call(this);
     });
 
-    Utils.override(Overview.Overview, '_eosHideOrShowApps', function() {
+    Utils.override(Overview.Overview, function _eosHideOrShowApps() {
         if (workspaceMonitor.hasVisibleWindows)
             this.hide();
         else
             Main.overview.dash.showAppsButton.checked = true;
     });
 
-    Utils.override(Overview.Overview, '_eosHideOrShowOverview', function() {
+    Utils.override(Overview.Overview, function _eosHideOrShowOverview() {
         if (workspaceMonitor.hasVisibleWindows)
             this.hide();
         else
             Main.overview.dash.showAppsButton.checked = false;
     });
 
-    Utils.override(Overview.Overview, 'runStartupAnimation', async function(callback) {
+    Utils.override(Overview.Overview, async function runStartupAnimation(callback) {
         const original = Utils.original(Overview.Overview, 'runStartupAnimation');
         original.call(this, () => {
             callback();

--- a/ui/overview.js
+++ b/ui/overview.js
@@ -91,12 +91,10 @@ function enable(workspaceMonitor) {
             Main.overview.dash.showAppsButton.checked = false;
     });
 
-    Utils.override(Overview.Overview, async function runStartupAnimation(callback) {
+    Utils.override(Overview.Overview, async function runStartupAnimation() {
         const original = Utils.original(Overview.Overview, 'runStartupAnimation');
-        original.call(this, () => {
-            callback();
-            this._startupAnimationDone = true;
-        });
+        await original.call(this);
+        this._startupAnimationDone = true;
     });
 
     addBackgroundToOverview();

--- a/ui/overview.js
+++ b/ui/overview.js
@@ -68,7 +68,9 @@ function removeBackgroundFromOverview() {
 
 function enable(workspaceMonitor) {
     Utils.override(Overview.Overview, function hide(bypassVisibleWindowCheck = false) {
-        if (!bypassVisibleWindowCheck && !workspaceMonitor.hasVisibleWindows) {
+        if (!bypassVisibleWindowCheck &&
+            !workspaceMonitor.hasVisibleWindows &&
+            this._startupAnimationDone) {
             Main.overview.dash.showAppsButton.checked = true;
             return;
         }

--- a/ui/overview.js
+++ b/ui/overview.js
@@ -74,7 +74,7 @@ function enable(workspaceMonitor) {
         }
 
         const original = Utils.original(Overview.Overview, 'hide');
-        original.bind(this)();
+        original.call(this);
     });
 
     Utils.override(Overview.Overview, '_eosHideOrShowApps', function() {
@@ -93,7 +93,7 @@ function enable(workspaceMonitor) {
 
     Utils.override(Overview.Overview, 'runStartupAnimation', async function(callback) {
         const original = Utils.original(Overview.Overview, 'runStartupAnimation');
-        original.bind(this)(() => {
+        original.call(this, () => {
             callback();
             this._startupAnimationDone = true;
         });

--- a/ui/overviewControls.js
+++ b/ui/overviewControls.js
@@ -326,7 +326,7 @@ function enable() {
 
     });
 
-    Utils.override(OverviewControls.ControlsManager, async function runStartupAnimation(callback) {
+    Utils.override(OverviewControls.ControlsManager, async function runStartupAnimation() {
         this._ignoreShowAppsButtonToggle = true;
 
         this._searchController.prepareToEnterOverview();
@@ -367,17 +367,19 @@ function enable() {
         // The Dash rises from the bottom. This is the last animation to finish,
         // so run the callback there.
         this.dash.translation_y = this.dash.height;
-        this.dash.ease({
-            translation_y: 0,
-            delay: STARTUP_ANIMATION_TIME,
-            duration: STARTUP_ANIMATION_TIME,
-            mode: Clutter.AnimationMode.EASE_OUT_QUAD,
-            onStopped: (isFinished) => {
-                if (!isFinished)
-                    this.dash.translation_y = 0;
+        return new Promise(resolve => {
+            this.dash.ease({
+                translation_y: 0,
+                delay: STARTUP_ANIMATION_TIME,
+                duration: STARTUP_ANIMATION_TIME,
+                mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+                onStopped: (isFinished) => {
+                    if (!isFinished)
+                        this.dash.translation_y = 0;
 
-                callback();
-            }
+                    resolve();
+                }
+            });
         });
     });
 

--- a/ui/overviewControls.js
+++ b/ui/overviewControls.js
@@ -262,7 +262,7 @@ function setDashAboveWorkspaces(above) {
 }
 
 function enable() {
-    Utils.override(OverviewControls.ControlsManager, '_updateAppDisplayVisibility', function (params) {
+    Utils.override(OverviewControls.ControlsManager, function _updateAppDisplayVisibility(params) {
         if (!params)
             params = this._stateAdjustment.getStateTransitionParams();
 
@@ -326,7 +326,7 @@ function enable() {
 
     });
 
-    Utils.override(OverviewControls.ControlsManager, 'runStartupAnimation', async function (callback) {
+    Utils.override(OverviewControls.ControlsManager, async function runStartupAnimation(callback) {
         this._ignoreShowAppsButtonToggle = true;
 
         this._searchController.prepareToEnterOverview();

--- a/ui/search.js
+++ b/ui/search.js
@@ -95,7 +95,7 @@ function setInternetSearchProviderEnable(enabled) {
 }
 
 function enable() {
-    Utils.override(Search.SearchResult, 'activate', function () {
+    Utils.override(Search.SearchResult, function activate() {
         const original = Utils.original(Search.SearchResult, 'activate');
         original.call(this);
         // The original activate() calls Main.overview.toggle(), which hides
@@ -105,7 +105,7 @@ function enable() {
         Main.overview.hide(true);
     });
 
-    Utils.override(Search.ListSearchResults, '_init', function (provider, resultsView) {
+    Utils.override(Search.ListSearchResults, function _init(provider, resultsView) {
         const original = Utils.original(Search.ListSearchResults, '_init');
         original.call(this, provider, resultsView);
         this.providerInfo.connect('clicked', () => {

--- a/ui/search.js
+++ b/ui/search.js
@@ -97,7 +97,7 @@ function setInternetSearchProviderEnable(enabled) {
 function enable() {
     Utils.override(Search.SearchResult, 'activate', function () {
         const original = Utils.original(Search.SearchResult, 'activate');
-        original.bind(this)();
+        original.call(this);
         // The original activate() calls Main.overview.toggle(), which hides
         // the overview, but (due to our customizations in overview.js) only if
         // windows are visible. We expect a window to appear whenever a search
@@ -107,7 +107,7 @@ function enable() {
 
     Utils.override(Search.ListSearchResults, '_init', function (provider, resultsView) {
         const original = Utils.original(Search.ListSearchResults, '_init');
-        original.bind(this)(provider, resultsView);
+        original.call(this, provider, resultsView);
         this.providerInfo.connect('clicked', () => {
             Main.overview.hide(true);
         });

--- a/ui/workspace.js
+++ b/ui/workspace.js
@@ -64,7 +64,7 @@ function getBorderOpacityForState(state) {
 }
 
 function enable() {
-    Utils.override(Workspace.Workspace, '_init', function(metaWorkspace, monitorIndex, overviewAdjustment) {
+    Utils.override(Workspace.Workspace, function _init(metaWorkspace, monitorIndex, overviewAdjustment) {
         const original = Utils.original(Workspace.Workspace, '_init');
         original.call(this, metaWorkspace, monitorIndex, overviewAdjustment);
 
@@ -95,7 +95,7 @@ function enable() {
         });
     });
 
-    Utils.override(Workspace.Workspace, '_onDestroy', function() {
+    Utils.override(Workspace.Workspace, function _onDestroy() {
         if (this._overviewStateChangedId) {
             this._overviewAdjustment.disconnect(this._overviewStateChangedId);
             delete this._overviewStateChangedId;

--- a/ui/workspace.js
+++ b/ui/workspace.js
@@ -66,7 +66,7 @@ function getBorderOpacityForState(state) {
 function enable() {
     Utils.override(Workspace.Workspace, '_init', function(metaWorkspace, monitorIndex, overviewAdjustment) {
         const original = Utils.original(Workspace.Workspace, '_init');
-        original.bind(this)(metaWorkspace, monitorIndex, overviewAdjustment);
+        original.call(this, metaWorkspace, monitorIndex, overviewAdjustment);
 
         this._background.hide();
 
@@ -102,7 +102,7 @@ function enable() {
         }
 
         const original = Utils.original(Workspace.Workspace, '_onDestroy');
-        original.bind(this)();
+        original.call(this);
     });
 }
 

--- a/utils.js
+++ b/utils.js
@@ -10,7 +10,9 @@ var gettext = Gettext.gettext;
 
 var GS_ = imports.gettext.domain('gnome-shell').gettext;
 
-function override(object, methodName, callback) {
+function override(object, callback) {
+    const methodName = callback.name;
+
     if (!object._desktopFnOverrides)
         object._desktopFnOverrides = {};
 


### PR DESCRIPTION
Mutually depends on:

- https://github.com/endlessm/gnome-shell/pull/760

We override Overview.hide() in such a way that in some cases it actually
ends up showing the overview. Specifically, if there are no visible
windows, the overridden implementation causes the show-apps button to be
pressed; and a ::notify::checked handler for that button in our
extension causes the overview to be shown in some cases.

This was implemented in commit https://github.com/endlessm/eos-desktop-extension/commit/248196ec6917b4152859f5aae619e2fccf8a4cd5
for reasons explained there.

One case where Overview.hide() is called is in response to
MetaMonitorManager::monitors-changed, from Overview._relayout(). This
can happen very early in the session, even before the startup animation
has run. This would cause the overview's state to be changed to SHOWING
before the startup animation runs. Then when the startup animation
attempts to change the state to SHOWING, an exception was raised because
SHOWING → SHOWING is not a legal state transition.

Avoid this by not adjusting the show-apps button in the overridden
Overview.hide() method if the startup animation has not yet run.

In addition, adapt to the changes in https://github.com/endlessm/gnome-shell/pull/760 which improve the error reporting and guard against this whole family of bugs. Plus make some changes to the way we override shell methods to improve backtraces.

The one-line fix in the last commit is the actual fix!

https://phabricator.endlessm.com/T34453