### PR TITLE
Fix large memory leak whenever the extension is disabled and enabled

### DIFF
--- a/ui/appDisplay.js
+++ b/ui/appDisplay.js
@@ -41,21 +41,7 @@ function rebuildAppGrid() {
     appDisplay._redisplay();
 }
 
-let overviewHidingId = 0;
-let overviewHiddenId = 0;
-let hidingOverview = false;
-
 function enable() {
-    Utils.override(AppDisplay.AppDisplay,
-        function goToPage(pageNumber, animate = true) {
-            const original = Utils.original(AppDisplay.AppDisplay, 'goToPage');
-
-            if (hidingOverview)
-                return;
-
-            original.call(this, pageNumber, animate);
-        });
-
     Utils.override(AppDisplay.AppIcon, function activate(button) {
         const original = Utils.original(AppDisplay.AppIcon, 'activate');
         original.call(this, button);
@@ -103,20 +89,6 @@ function enable() {
         return [page, position];
     });
 
-    // This relies on the fact that signals are emitted in the
-    // order they are connected. Which means, AppDisplay will
-    // receive the 'hidden' signal first, then we will receive
-    // after, which guarantees that 'hidingOverview' is set to
-    // true during the precise time we want
-    overviewHidingId =
-        Main.overview.connect('hiding', () => {
-            hidingOverview = true;
-        });
-    overviewHiddenId =
-        Main.overview.connect('hidden', () => {
-            hidingOverview = false;
-        });
-
     rebuildAppGrid();
 }
 
@@ -124,9 +96,6 @@ function disable() {
     Utils.restore(AppDisplay.AppDisplay);
     Utils.restore(AppDisplay.AppIcon);
     Utils.restore(AppDisplay.PageManager);
-
-    Main.overview.disconnect(overviewHidingId);
-    Main.overview.disconnect(overviewHiddenId);
 
     rebuildAppGrid();
 }

--- a/ui/appDisplay.js
+++ b/ui/appDisplay.js
@@ -25,22 +25,6 @@ const AppDisplay = imports.ui.appDisplay;
 const Main = imports.ui.main;
 const Utils = DesktopExtension.imports.utils;
 
-function rebuildAppGrid() {
-    const { appDisplay } = Main.overview._overview.controls;
-
-    appDisplay._items.clear();
-    appDisplay._orderedItems.splice(0, appDisplay._orderedItems.length);
-
-    const grid = appDisplay._grid;
-    while (grid.nPages > 0) {
-        const items = appDisplay._grid.getItemsAtPage(grid.nPages - 1);
-        for (const item of items)
-            appDisplay._grid.removeItem(item);
-    }
-
-    appDisplay._redisplay();
-}
-
 function enable() {
     Utils.override(AppDisplay.AppIcon, function activate(button) {
         const original = Utils.original(AppDisplay.AppIcon, 'activate');
@@ -88,14 +72,10 @@ function enable() {
 
         return [page, position];
     });
-
-    rebuildAppGrid();
 }
 
 function disable() {
     Utils.restore(AppDisplay.AppDisplay);
     Utils.restore(AppDisplay.AppIcon);
     Utils.restore(AppDisplay.PageManager);
-
-    rebuildAppGrid();
 }

--- a/ui/overviewControls.js
+++ b/ui/overviewControls.js
@@ -261,6 +261,18 @@ function setDashAboveWorkspaces(above) {
         controls.set_child_below_sibling(controls.dash, controls._searchController);
 }
 
+function restoreAppDisplay() {
+    let { controls } = Main.overview._overview;
+
+    /* In vanilla Shell, _appDisplay.opacity depends only on whether search is
+     * active, while this extension also uses it to fade the grid in and out
+     * when you enter and leave the APP_GRID state. Restore it to the value it
+     * would have had in vanilla Shell.
+     */
+    let { searchActive } = controls._searchController;
+    controls._appDisplay.opacity = searchActive ? 0 : 255;
+}
+
 function enable() {
     Utils.override(OverviewControls.ControlsManager, function _updateAppDisplayVisibility(params) {
         if (!params)
@@ -386,5 +398,7 @@ function enable() {
 
 function disable() {
     Utils.restore(OverviewControls.ControlsManager);
+
     restoreOverviewLayoutManager();
+    restoreAppDisplay();
 }

--- a/ui/overviewControls.js
+++ b/ui/overviewControls.js
@@ -268,17 +268,15 @@ function enable() {
 
         const { searchActive } = this._searchController;
         const { currentState, initialState, finalState, progress } = params;
+        const state = Math.max(initialState, finalState);
 
         if (!searchActive) {
-            this._appDisplay.visible = true;
+            this._appDisplay.visible =
+                state > OverviewControls.ControlsState.WINDOW_PICKER;
             this._appDisplay.opacity = ShellUtils.lerp(
                 getAppDisplayOpacityForState(initialState),
                 getAppDisplayOpacityForState(finalState),
                 progress);
-
-            Shell.util_set_hidden_from_pick(
-                this._appDisplay,
-                currentState <= OverviewControls.ControlsState.WINDOW_PICKER);
         }
 
         setDashAboveWorkspaces(currentState < OverviewControls.ControlsState.WINDOW_PICKER);


### PR DESCRIPTION
Whenever the screen is locked and unlocked, all extensions are, respectively, disabled and enabled. So even though we do not expect users to toggle this extension in regular use, and so do not strictly need the session to be functional when it is manually disabled, we do need turning it off and on again to not cause issues.

Unfortunately, when I disable and re-enable the extension the `gnome-shell` process's resident set size (non-swapped physical memory) grows by (on my system) 30 MiB each time. This also causes the desktop session to become steadily less usable over time. (When testing this, put a `sleep 5` in between each command to disable or enable the extension; if you turn it off and on in a tight loop, gnome-shell crashes, which is bad but I haven't investigated further)

The problem is due to some code which removes all icons from the grid, then recreates the grid, whenever the extension is enabled or disabled. This was introduced in commit f1287c8770299d62f3d7fbefc9430e6b4661b111.
    
It is not totally clear from the commit message what issue this was trying to address. I have some faint memory of it being to do with the real app grid and its desaturated clone getting out of sync, though I don't remember the details.

Unfortunately it appears that this function leaks all the icons it removes. I imagine this leak is proportional to the number of app icons in the grid. I have around 330 app icons on the system in question.

Removing this function cures the leak: RSS does not grow as I repeatedly toggle the extension. It also makes locking and unlocking the screen very noticably snappier. And I don't notice any regressions from removing this code.

(I didn't actually investigate the cause of the leak any further but my assumption is that some C-level reference to the removed items remains, causing them not to be GCed.)

This PR removes the problematic function. It also removes some code that no longer performs its intended function for unknown reasons.

Historically, if you disable the extension, the session is not fully usable until you re-enable it: the app grid and dash both disappear. I figured out why the app grid disappears and fixed it in this series. I have not yet fixed the dash, though I'm pretty sure it's because the extension reparents the dash from the overview into an actor supplied by this extension; when the extension is disabled, it does not return the dash to its original parent.

https://phabricator.endlessm.com/T35677